### PR TITLE
Add Node build server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,16 @@
-# ultipaw by Enzo
+# UltiPaw
+
+This repository contains a Unity package. The original GitHub pipeline built release packages automatically.
+
+A simple Node.js server script `server.js` provides an endpoint to build the same packages locally. It zips the repository and creates a `.unitypackage` using the meta files.
+
+## Usage
+
+Install dependencies and start the server:
+
+```bash
+npm install
+npm start
+```
+
+Trigger a build by visiting `http://localhost:3000/build`.

--- a/package.json
+++ b/package.json
@@ -6,7 +6,10 @@
   "description": "Wizard to install the UltiPaw on a winterpaw",
   "type": "tool",
   "url":  "https://github.com/blackorbit1/orbiters-vpm/raw/refs/heads/main/ultipaw.0.0.1.zip",
-  "dependencies": {},
+  "dependencies": {
+    "express": "^4.18.2",
+    "fs-extra": "^11.1.1"
+  },
   "gitDependencies": {},
   "vpmDependencies": {
     "com.vrchat.avatars": "3.8.0"
@@ -17,5 +20,7 @@
     "url": "orbiters.cc"
   },
   "legacyFolders": {},
-  "legacyFiles": {}
-}
+  "legacyFiles": {},
+  "scripts": {
+    "start": "node server.js"
+  }}

--- a/server.js
+++ b/server.js
@@ -1,0 +1,64 @@
+const express = require('express');
+const fs = require('fs');
+const fsp = fs.promises;
+const path = require('path');
+const os = require('os');
+const { execSync } = require('child_process');
+
+const app = express();
+const PORT = process.env.PORT || 3000;
+
+async function buildPackage() {
+  const pkg = JSON.parse(await fsp.readFile(path.join(__dirname, 'package.json'), 'utf8'));
+  const packageName = process.env.PACKAGE_NAME || pkg.name;
+  const version = pkg.version;
+
+  const zipFile = `${packageName}-${version}.zip`;
+  const unityPackage = `${packageName}-${version}.unitypackage`;
+
+  if (fs.existsSync(zipFile)) await fsp.unlink(zipFile);
+  if (fs.existsSync(unityPackage)) await fsp.unlink(unityPackage);
+
+  // Create zip archive of repository
+  execSync(`zip -r ${zipFile} . -x '*.git*' '*node_modules*'`, { stdio: 'inherit' });
+
+  // Find all meta files
+  const metaList = execSync("find . -name '*.meta' -print").toString().trim().split('\n').filter(Boolean);
+  const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'unitypkg-'));
+
+  for (const metaPath of metaList) {
+    const assetPath = metaPath.replace(/\.meta$/, '');
+    const metaContent = await fsp.readFile(metaPath, 'utf8');
+    const match = metaContent.match(/guid:\s*(\S+)/);
+    if (!match) continue;
+    const guid = match[1];
+    const outDir = path.join(tmpDir, guid);
+    await fsp.mkdir(outDir, { recursive: true });
+    if (fs.existsSync(assetPath) && fs.lstatSync(assetPath).isFile()) {
+      await fsp.copyFile(assetPath, path.join(outDir, 'asset'));
+    } else {
+      await fsp.writeFile(path.join(outDir, 'asset'), '');
+    }
+    await fsp.copyFile(metaPath, path.join(outDir, 'asset.meta'));
+    await fsp.writeFile(path.join(outDir, 'pathname'), assetPath.replace(/^\.\//, ''));
+  }
+
+  execSync(`tar -czf ${unityPackage} -C ${tmpDir} .`);
+  await fsp.rm(tmpDir, { recursive: true, force: true });
+
+  return { zipFile, unityPackage };
+}
+
+app.get('/build', async (req, res) => {
+  try {
+    const result = await buildPackage();
+    res.json(result);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: String(err) });
+  }
+});
+
+app.listen(PORT, () => {
+  console.log(`Server listening on port ${PORT}`);
+});


### PR DESCRIPTION
## Summary
- add a Node.js server that replicates the release workflow
- update package.json with server dependencies and start script
- update README with basic instructions

## Testing
- `npm install` *(fails: registry access blocked)*
- `node server.js` *(fails: cannot find module 'express' because dependencies cannot install)*

------
https://chatgpt.com/codex/tasks/task_e_686e98d09fc4832a9ee7067c88813151